### PR TITLE
Android reorder

### DIFF
--- a/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/activities/LoginActivity.java
+++ b/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/activities/LoginActivity.java
@@ -3,7 +3,6 @@ package com.hopsquad.hopsquadapp.activities;
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.TargetApi;
-import android.app.DialogFragment;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProviders;
@@ -89,8 +88,8 @@ public class LoginActivity extends BaseActivity {
             @Override
             public void onFocusChange(View view, boolean gotFocus) {
                 if (gotFocus) {
-                    DialogFragment newFragment = new DatePickerFragment();
-                    newFragment.show(getFragmentManager(), "datePicker");
+                    DatePickerFragment newFragment = new DatePickerFragment();
+                    newFragment.show(getSupportFragmentManager(), "datePicker");
                 }
             }
         });

--- a/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/api/WebServiceRepository.java
+++ b/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/api/WebServiceRepository.java
@@ -103,15 +103,34 @@ public class WebServiceRepository {
 
                 ArrayList<HistoryOrder> filteredValue = new ArrayList<>();
                 for (HistoryOrder order : value) {
-//                    if (userId != null && userId.equals(order.userId)) {
+                    if (userId != null && userId.equals(order.userId)) {
                         filteredValue.add(order);
                         if (filteredValue.size() == 3) {
                             break;
                         }
-//                    }
+                    }
                 }
 
                 data.setValue(filteredValue);
+            }
+
+            @Override
+            public void onFailure(Call<List<HistoryOrder>> call, Throwable t) {
+                t.printStackTrace();
+            }
+        });
+
+        return data;
+    }
+
+    public LiveData<List<HistoryOrder>> getAllOrdersByUser(String userId) {
+        final MutableLiveData<List<HistoryOrder>> data = new MutableLiveData<>();
+
+        getAllOrdersWebService.getAllOrdersByUserId(userId, 5).enqueue(new Callback<List<HistoryOrder>>() {
+            @Override
+            public void onResponse(Call<List<HistoryOrder>> call, Response<List<HistoryOrder>> response) {
+                List<HistoryOrder> value = response.isSuccessful() ? response.body() : new ArrayList<>();
+                data.setValue(value);
             }
 
             @Override

--- a/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/api/Webservice.java
+++ b/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/api/Webservice.java
@@ -11,6 +11,8 @@ import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
 
 /**
  * Created by memo on 15/11/17.
@@ -27,7 +29,10 @@ public interface Webservice {
     Call<List<HistoryOrder>> getAllOrders();
 
     @GET("/api/get_all_orders_by_user")
-    Call<List<HistoryOrder>> getAllOrdersByUserId(String userId);
+    Call<List<HistoryOrder>> getAllOrdersByUserId(@Query("userId") String userId);
+
+    @GET("/api/get_all_orders_by_user")
+    Call<List<HistoryOrder>> getAllOrdersByUserId(@Query("userId") String userId, @Query("limit") int limit);
 
     @POST("/api/add_order")
     Call<Order> addOrder(@Body Order order);

--- a/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/fragments/BaseDialogFragment.java
+++ b/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/fragments/BaseDialogFragment.java
@@ -1,6 +1,6 @@
 package com.hopsquad.hopsquadapp.fragments;
 
-import android.app.DialogFragment;
+import android.support.v4.app.DialogFragment;
 
 /**
  * Created by memoak on 11/25/2017.

--- a/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/fragments/ConfirmOrderFragment.java
+++ b/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/fragments/ConfirmOrderFragment.java
@@ -2,34 +2,46 @@ package com.hopsquad.hopsquadapp.fragments;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
-import android.arch.lifecycle.ViewModelProviders;
-import android.content.DialogInterface;
 import android.os.Bundle;
-import android.support.v4.app.DialogFragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 
 import com.hopsquad.hopsquadapp.R;
-import com.hopsquad.hopsquadapp.activities.MainActivity;
-import com.hopsquad.hopsquadapp.models.Order;
-import com.hopsquad.hopsquadapp.viewmodels.TapListViewModel;
 
 import java.text.NumberFormat;
 
-public class ConfirmOrderFragment extends DialogFragment {
+public class ConfirmOrderFragment extends BaseDialogFragment {
+
+    private static final String TOTAL_PRICE_TO_PAY = "TOTAL_PRICE";
+    private OnConfirmDialogOptionSelectedListener mListener;
+    private float mTotal;
+
+    public interface OnConfirmDialogOptionSelectedListener {
+
+        void onConfirmDialogOptionSelected(boolean confirmed);
+    }
+
+    public static ConfirmOrderFragment newInstance(float total) {
+        ConfirmOrderFragment fragment = new ConfirmOrderFragment();
+        Bundle args = new Bundle();
+        args.putFloat(TOTAL_PRICE_TO_PAY, total);
+        fragment.setArguments(args);
+        return fragment;
+    }
 
     public ConfirmOrderFragment() {
         // Required empty public constructor
     }
 
-    TapListViewModel viewModel;
+    public void setOnConfirmDialogOptionSelectedListener(OnConfirmDialogOptionSelectedListener listener) {
+        this.mListener = listener;
+    }
 
     @Override
     public void onCreate(Bundle savedInstaceState) {
         super.onCreate(savedInstaceState);
-
-        viewModel = ViewModelProviders.of(getTapListFragment()).get(TapListViewModel.class);
+        mTotal = getArguments().getFloat(TOTAL_PRICE_TO_PAY);
     }
 
     @Override
@@ -39,42 +51,17 @@ public class ConfirmOrderFragment extends DialogFragment {
         View dialogView = inflater.inflate(R.layout.fragment_confirm_order, null);
 
         TextView totalTextView = dialogView.findViewById(R.id.totalConfirmationDialogText);
-        totalTextView.setText(NumberFormat.getCurrencyInstance().format(viewModel.getOrderTotal()));
+        totalTextView.setText(NumberFormat.getCurrencyInstance().format(mTotal));
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setView(dialogView)
                 .setTitle(R.string.confirm_order_dialog_title)
-                .setPositiveButton(R.string.confirm_order_dialog_button, new DialogClickHandler(this, UserAction.ACCEPTED))
-                .setNegativeButton(R.string.cancel_order_button_dialog, new DialogClickHandler(this, UserAction.CANCELED));
+                .setPositiveButton(R.string.confirm_order_dialog_button, (dialogInterface, i) -> {
+                    mListener.onConfirmDialogOptionSelected(true);
+                })
+                .setNegativeButton(R.string.cancel_order_button_dialog, (dialogInterface, i) -> {
+                    mListener.onConfirmDialogOptionSelected(false);
+                });
         return builder.create();
-    }
-
-    private TapListFragment getTapListFragment() {
-        return (TapListFragment) getFragmentManager().findFragmentByTag(MainActivity.TAP_LIST_FRAGMENT_TAG);
-    }
-
-    private enum UserAction { CANCELED, ACCEPTED };
-
-    private static class DialogClickHandler implements DialogInterface.OnClickListener {
-        private UserAction action;
-        private ConfirmOrderFragment fragment;
-
-        public DialogClickHandler(ConfirmOrderFragment fragment, UserAction action) {
-            this.fragment = fragment;
-            this.action = action;
-        }
-
-        private boolean wasCanceled() {
-            return action == UserAction.CANCELED;
-        }
-
-        @Override
-        public void onClick(DialogInterface dialogInterface, int i) {
-            if (wasCanceled()) {
-                dialogInterface.cancel();
-            } else {
-                fragment.getTapListFragment().confirmOrder();
-            }
-        }
     }
 }

--- a/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/fragments/TapListFragment.java
+++ b/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/fragments/TapListFragment.java
@@ -38,6 +38,7 @@ import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
 import com.hopsquad.hopsquadapp.R;
+import com.hopsquad.hopsquadapp.framework.PayWithGoogleService;
 import com.hopsquad.hopsquadapp.models.Beer;
 import com.hopsquad.hopsquadapp.api.WebServiceRepository;
 import com.hopsquad.hopsquadapp.models.Order;
@@ -47,56 +48,18 @@ import com.squareup.picasso.Picasso;
 import java.text.NumberFormat;
 import java.util.Arrays;
 
-public class TapListFragment extends BaseFragment {
+public class TapListFragment extends BaseFragment implements ConfirmOrderFragment.OnConfirmDialogOptionSelectedListener {
 
-    public static final int LOAD_PAYMENT_DATA_REQUEST_CODE = 38192;
     private RecyclerView mRecyclerView;
     private RecyclerView.LayoutManager mLayoutManager;
     private BeerAdapter mAdapter;
     private FloatingActionButton placeOrderBtn;
-    private PaymentsClient mPaymentsClient;
-
     private TapListViewModel viewModel;
+    private PayWithGoogleService payService;
+
 
     public TapListFragment() {
         // Required empty public constructor
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-
-        switch (requestCode) {
-            case LOAD_PAYMENT_DATA_REQUEST_CODE:
-                switch (resultCode) {
-                    case Activity.RESULT_OK:
-                        PaymentData paymentData = PaymentData.getFromIntent(data);
-                        // You can get some data on the user's card, such as the brand and last 4 digits
-                        CardInfo info = paymentData.getCardInfo();
-                        // You can also pull the user address from the PaymentData object.
-                        UserAddress address = paymentData.getShippingAddress();
-                        // This is the raw JSON string version of your Stripe token.
-                        String rawToken = paymentData.getPaymentMethodToken().getToken();
-
-                        registerPlacedOrder(rawToken);
-
-                        break;
-                    case Activity.RESULT_CANCELED:
-                        break;
-                    case AutoResolveHelper.RESULT_ERROR:
-                        Status status = AutoResolveHelper.getStatusFromIntent(data);
-                        // Log the status for debugging
-                        // Generally there is no need to show an error to
-                        // the user as the Google Payment API will do that
-                        break;
-                    default:
-                        // Do nothing.
-                }
-                break; // Breaks the case LOAD_PAYMENT_DATA_REQUEST_CODE
-            // Handle any other startActivityForResult calls you may have made.
-            default:
-                // Do nothing.
-        }
     }
 
     @Override
@@ -107,31 +70,7 @@ public class TapListFragment extends BaseFragment {
         viewModel.setRepository(new WebServiceRepository());
         viewModel.init();
 
-        initializePaymentsClient();
-    }
-
-    private void initializePaymentsClient() {
-        mPaymentsClient = Wallet.getPaymentsClient(this.getContext(), new Wallet.WalletOptions.Builder()
-                .setEnvironment(WalletConstants.ENVIRONMENT_TEST).build());
-
-        IsReadyToPayRequest request = IsReadyToPayRequest.newBuilder()
-                .addAllowedPaymentMethod(WalletConstants.PAYMENT_METHOD_CARD)
-                .addAllowedPaymentMethod(WalletConstants.PAYMENT_METHOD_TOKENIZED_CARD)
-                .build();
-
-        Task<Boolean> task = mPaymentsClient.isReadyToPay(request);
-        task.addOnCompleteListener(new OnCompleteListener<Boolean>() {
-            @Override
-            public void onComplete(@NonNull Task<Boolean> task) {
-                try {
-                    boolean result = task.getResult(ApiException.class);
-                    viewModel.setIsReadyToPay(result);
-
-                } catch (ApiException apie) {
-                    apie.printStackTrace();
-                }
-            }
-        });
+        payService = new PayWithGoogleService(this.getContext());
     }
 
     @Override
@@ -144,6 +83,29 @@ public class TapListFragment extends BaseFragment {
 
         initializeViews();
         return v;
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        String token = null;
+
+        if (payService.canHandleRequestCode(requestCode)) {
+            payService.handleActivityResult(resultCode, data);
+            token = payService.getResultToken();
+        }
+
+        if (token != null) {
+            registerPlacedOrder(token);
+        }
+    }
+
+    @Override
+    public void onConfirmDialogOptionSelected(boolean confirmed) {
+        if (confirmed) {
+            payService.confirmOrder(this.getActivity(), viewModel.getOrderTotal());
+        }
     }
 
     private void initializeViews() {
@@ -168,7 +130,8 @@ public class TapListFragment extends BaseFragment {
     }
 
     private void displayOrderConfirmation() {
-        ConfirmOrderFragment confirmDialog = new ConfirmOrderFragment();
+        ConfirmOrderFragment confirmDialog = ConfirmOrderFragment.newInstance(viewModel.getOrderTotal());
+        confirmDialog.setOnConfirmDialogOptionSelectedListener(this);
         confirmDialog.show(this.getFragmentManager(), "CONFIRM_ORDER");
     }
 
@@ -187,30 +150,17 @@ public class TapListFragment extends BaseFragment {
             });
     }
 
-    public void confirmOrder() {
-        PaymentDataRequest request = createPaymentDataRequest();
-        if (request != null) {
-            AutoResolveHelper.resolveTask(mPaymentsClient.loadPaymentData(request),
-                    this.getActivity(),
-                    LOAD_PAYMENT_DATA_REQUEST_CODE);
-        }
-    }
-
     private void registerPlacedOrder(String token) {
         final LiveData<Order> orderLiveData = viewModel.placeOrder(token);
         final TapListFragment tapListFragment = this;
-        orderLiveData.observe(tapListFragment, new Observer<Order>() {
-            @Override
-            public void onChanged(@Nullable Order order) {
-
-                if (order == null || order.invoice == null) {
-                    tapListFragment.showToast(R.string.order_confirmation_generic_error);
-                } else {
-                    tapListFragment.showToast(R.string.order_succesfully_placed_msg);
-                    viewModel.clearOrder();
-                    refreshBeerList();
-                    orderLiveData.removeObservers(tapListFragment);
-                }
+        orderLiveData.observe(tapListFragment, order -> {
+            if (order == null || order.invoice == null) {
+                tapListFragment.showToast(R.string.order_confirmation_generic_error);
+            } else {
+                tapListFragment.showToast(R.string.order_succesfully_placed_msg);
+                viewModel.clearOrder();
+                refreshBeerList();
+                orderLiveData.removeObservers(tapListFragment);
             }
         });
     }
@@ -220,41 +170,6 @@ public class TapListFragment extends BaseFragment {
         mAdapter.isRefreshing = true;
         mRecyclerView.setAdapter(mAdapter);
         mAdapter.isRefreshing = false;
-    }
-
-    private PaymentDataRequest createPaymentDataRequest() {
-        String totalPrice = String.format("%.2f", viewModel.getOrderTotal());
-        PaymentDataRequest.Builder request =
-                PaymentDataRequest.newBuilder()
-                        .setTransactionInfo(
-                                TransactionInfo.newBuilder()
-
-                                        .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
-                                        .setTotalPrice(totalPrice)
-                                        .setCurrencyCode("USD")
-                                        .build())
-                        .addAllowedPaymentMethod(WalletConstants.PAYMENT_METHOD_CARD)
-                        .addAllowedPaymentMethod(WalletConstants.PAYMENT_METHOD_TOKENIZED_CARD)
-                        .setCardRequirements(
-                                CardRequirements.newBuilder()
-                                        .addAllowedCardNetworks(Arrays.asList(
-                                                WalletConstants.CARD_NETWORK_AMEX,
-                                                WalletConstants.CARD_NETWORK_DISCOVER,
-                                                WalletConstants.CARD_NETWORK_VISA,
-                                                WalletConstants.CARD_NETWORK_MASTERCARD))
-                                        .build());
-
-        request.setPaymentMethodTokenizationParameters(createTokenizationParameters());
-        return request.build();
-    }
-
-    private PaymentMethodTokenizationParameters createTokenizationParameters() {
-        return PaymentMethodTokenizationParameters.newBuilder()
-                .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
-                .addParameter("gateway", "stripe")
-                .addParameter("stripe:publishableKey", WebServiceRepository.STRIPE_PUBLISHABLE_KEY)
-                .addParameter("stripe:version", "5.1.0")
-                .build();
     }
 
     private static class BeerAdapter extends RecyclerView.Adapter<BeerHolder> {
@@ -299,6 +214,10 @@ public class TapListFragment extends BaseFragment {
                 }
             });
             holder.mSpinnerView.setSelection(tapList.getQuantityOrdered(b.id), true);
+            holder.mSpinnerView.setEnabled(b.on_tap);
+            if (!b.on_tap) {
+                holder.mPriceView.setText("$--.--");
+            }
 
             String thumbnail_uri = b.tap_list_image;
             Picasso.with(context).load(thumbnail_uri).into(holder.mImageView);

--- a/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/framework/PayWithGoogleService.java
+++ b/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/framework/PayWithGoogleService.java
@@ -1,0 +1,139 @@
+package com.hopsquad.hopsquadapp.framework;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+
+import com.google.android.gms.common.api.ApiException;
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.identity.intents.model.UserAddress;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.wallet.AutoResolveHelper;
+import com.google.android.gms.wallet.CardInfo;
+import com.google.android.gms.wallet.CardRequirements;
+import com.google.android.gms.wallet.IsReadyToPayRequest;
+import com.google.android.gms.wallet.PaymentData;
+import com.google.android.gms.wallet.PaymentDataRequest;
+import com.google.android.gms.wallet.PaymentMethodTokenizationParameters;
+import com.google.android.gms.wallet.PaymentsClient;
+import com.google.android.gms.wallet.TransactionInfo;
+import com.google.android.gms.wallet.Wallet;
+import com.google.android.gms.wallet.WalletConstants;
+import com.hopsquad.hopsquadapp.api.WebServiceRepository;
+
+import java.util.Arrays;
+
+/**
+ * Created by memoak on 11/27/2017.
+ */
+
+public class PayWithGoogleService {
+
+    public static final int LOAD_PAYMENT_DATA_REQUEST_CODE = 38192;
+
+    private PaymentsClient mPaymentsClient;
+    private boolean isReadyToPay = false;
+    private String mResultToken = null;
+
+    public PayWithGoogleService(Context context) {
+        initializePaymentsClient(context);
+    }
+
+    public void confirmOrder(Activity context, float total) {
+        PaymentDataRequest request = createPaymentDataRequest(total);
+        if (request != null) {
+            AutoResolveHelper.resolveTask(mPaymentsClient.loadPaymentData(request),
+                    context,
+                    LOAD_PAYMENT_DATA_REQUEST_CODE);
+        }
+    }
+
+    private void initializePaymentsClient(Context context) {
+        mPaymentsClient = Wallet.getPaymentsClient(context, new Wallet.WalletOptions.Builder()
+                .setEnvironment(WalletConstants.ENVIRONMENT_TEST).build());
+
+        IsReadyToPayRequest request = IsReadyToPayRequest.newBuilder()
+                .addAllowedPaymentMethod(WalletConstants.PAYMENT_METHOD_CARD)
+                .addAllowedPaymentMethod(WalletConstants.PAYMENT_METHOD_TOKENIZED_CARD)
+                .build();
+
+        Task<Boolean> task = mPaymentsClient.isReadyToPay(request);
+        task.addOnCompleteListener(task1 -> {
+            try {
+                boolean result = task1.getResult(ApiException.class);
+                isReadyToPay = result;
+
+            } catch (ApiException apie) {
+                apie.printStackTrace();
+            }
+        });
+    }
+
+    public boolean canHandleRequestCode(int requestCode) {
+        return requestCode == LOAD_PAYMENT_DATA_REQUEST_CODE;
+    }
+
+    public void handleActivityResult(int resultCode, Intent data) {
+        switch (resultCode) {
+            case Activity.RESULT_OK:
+                PaymentData paymentData = PaymentData.getFromIntent(data);
+                // This is the raw JSON string version of your Stripe token.
+                String rawToken = paymentData.getPaymentMethodToken().getToken();
+
+                mResultToken = rawToken;
+
+                break;
+            case Activity.RESULT_CANCELED:
+                break;
+            case AutoResolveHelper.RESULT_ERROR:
+                Status status = AutoResolveHelper.getStatusFromIntent(data);
+                // Log the status for debugging
+                // Generally there is no need to show an error to
+                // the user as the Google Payment API will do that
+                break;
+            default:
+                // Do nothing.
+        }
+    }
+
+    public String getResultToken() {
+        return mResultToken;
+    }
+
+    private PaymentDataRequest createPaymentDataRequest(float total) {
+        String totalPrice = String.format("%.2f", total);
+        PaymentDataRequest.Builder request =
+                PaymentDataRequest.newBuilder()
+                        .setTransactionInfo(
+                                TransactionInfo.newBuilder()
+
+                                        .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
+                                        .setTotalPrice(totalPrice)
+                                        .setCurrencyCode("USD")
+                                        .build())
+                        .addAllowedPaymentMethod(WalletConstants.PAYMENT_METHOD_CARD)
+                        .addAllowedPaymentMethod(WalletConstants.PAYMENT_METHOD_TOKENIZED_CARD)
+                        .setCardRequirements(
+                                CardRequirements.newBuilder()
+                                        .addAllowedCardNetworks(Arrays.asList(
+                                                WalletConstants.CARD_NETWORK_AMEX,
+                                                WalletConstants.CARD_NETWORK_DISCOVER,
+                                                WalletConstants.CARD_NETWORK_VISA,
+                                                WalletConstants.CARD_NETWORK_MASTERCARD))
+                                        .build());
+
+        request.setPaymentMethodTokenizationParameters(createTokenizationParameters());
+        return request.build();
+    }
+
+    private PaymentMethodTokenizationParameters createTokenizationParameters() {
+        return PaymentMethodTokenizationParameters.newBuilder()
+                .setPaymentMethodTokenizationType(WalletConstants.PAYMENT_METHOD_TOKENIZATION_TYPE_PAYMENT_GATEWAY)
+                .addParameter("gateway", "stripe")
+                .addParameter("stripe:publishableKey", WebServiceRepository.STRIPE_PUBLISHABLE_KEY)
+                .addParameter("stripe:version", "5.1.0")
+                .build();
+    }
+}

--- a/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/framework/PayWithGoogleService.java
+++ b/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/framework/PayWithGoogleService.java
@@ -23,6 +23,9 @@ import com.google.android.gms.wallet.Wallet;
 import com.google.android.gms.wallet.WalletConstants;
 import com.hopsquad.hopsquadapp.api.WebServiceRepository;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.util.Arrays;
 
 /**
@@ -99,7 +102,18 @@ public class PayWithGoogleService {
     }
 
     public String getResultToken() {
-        return mResultToken;
+        try {
+            return parseTokenInvoiceId(mResultToken);
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private String parseTokenInvoiceId(String token) throws JSONException {
+        JSONObject jsonObject = new JSONObject(token);
+        String token_id = jsonObject.getString("id");
+        return token_id;
     }
 
     private PaymentDataRequest createPaymentDataRequest(float total) {

--- a/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/models/BeerAndQuantity.java
+++ b/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/models/BeerAndQuantity.java
@@ -8,7 +8,9 @@ import com.google.gson.annotations.SerializedName;
  */
 
 public class BeerAndQuantity {
-    private String id;
+
+    public String id;
+
     public int quantity;
 
     @SerializedName("beer_name")

--- a/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/viewmodels/OrderHistoryViewModel.java
+++ b/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/viewmodels/OrderHistoryViewModel.java
@@ -1,15 +1,21 @@
 package com.hopsquad.hopsquadapp.viewmodels;
 
 import android.arch.lifecycle.LiveData;
+import android.arch.lifecycle.MutableLiveData;
 import android.arch.lifecycle.ViewModel;
 
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.hopsquad.hopsquadapp.api.WebServiceRepository;
+import com.hopsquad.hopsquadapp.models.Beer;
+import com.hopsquad.hopsquadapp.models.BeerAndQuantity;
 import com.hopsquad.hopsquadapp.models.HistoryOrder;
 import com.hopsquad.hopsquadapp.models.Order;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import static com.hopsquad.hopsquadapp.viewmodels.TapListViewModel.STATE_TAX;
 
 /**
  * Created by memoak on 11/26/2017.
@@ -18,11 +24,13 @@ import java.util.List;
 public class OrderHistoryViewModel extends ViewModel {
 
     private LiveData<List<HistoryOrder>> orderHistory;
+    private MutableLiveData<HistoryOrder> historyOrderSelected;
 
     private WebServiceRepository webRepo;
+    private LiveData<List<Beer>> tapList;
 
     public OrderHistoryViewModel() {
-
+        historyOrderSelected = new MutableLiveData<>();
     }
 
     public void setRepository(WebServiceRepository repo) {
@@ -30,16 +38,77 @@ public class OrderHistoryViewModel extends ViewModel {
     }
 
     public void init() {
-        orderHistory = webRepo.getAllOrders(getUserId());
+        tapList = webRepo.getAllBeers();
     }
 
     public LiveData<List<HistoryOrder>> getOrderHistory() {
+        orderHistory = webRepo.getAllOrdersByUser(getUserId());
         return orderHistory;
+    }
+
+    public void setHistoryOrderSelected(HistoryOrder order) {
+        historyOrderSelected.setValue(order);
+    }
+
+    public LiveData<HistoryOrder> getSelectedOrder() {
+        return historyOrderSelected;
     }
 
     private String getUserId() {
         FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
         return user.getUid();
+    }
+
+    public LiveData<Order> placeOrder(String token) {
+        HistoryOrder historyOrder = historyOrderSelected.getValue();
+
+        Order order = convertHistoryOrderToOrder(historyOrder);
+        order.invoice = token;
+
+        LiveData<Order> newOrder = webRepo.placeOrder(order);
+        return newOrder;
+    }
+
+    public Order convertHistoryOrderToOrder(HistoryOrder historyOrder) {
+        Order order = new Order();
+        float newTotal = 0.0f;
+        ArrayList<BeerAndQuantity> beerList = new ArrayList<>();
+        // No discounts re-applied :(
+        for(BeerAndQuantity beerAndQuantity : historyOrder.details) {
+            Beer beer = beerAndQuantity.id == null ? getBeerByName(beerAndQuantity.beerName) : getBeerById(beerAndQuantity.id);
+            // Tap list might have changed.
+            if (beer != null && beer.on_tap) {
+                newTotal += (beer.price * (1 + STATE_TAX / 100)) * beerAndQuantity.quantity;
+                // Fix null beerAndQuantity.id
+                beerAndQuantity.id = beer.id;
+                beerList.add(beerAndQuantity);
+            }
+
+        }
+        order.total = newTotal;
+        order.beers = beerList;
+        order.userId = historyOrder.userId;
+        return order;
+    }
+
+    private Beer getBeerById(String id) {
+        List<Beer> currentTapList = tapList.getValue();
+        for (Beer beer : currentTapList) {
+            if (beer.id.equals(id)) {
+                return beer;
+            }
+        }
+        return null;
+    }
+
+    private Beer getBeerByName(String name) {
+        List<Beer> currentTapList = tapList.getValue();
+        for (Beer beer : currentTapList) {
+            if (beer.name.equals(name)) {
+                return beer;
+            }
+        }
+        return null;
     }
 
 }

--- a/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/viewmodels/TapListViewModel.java
+++ b/androidapp/HopSquadApp/app/src/main/java/com/hopsquad/hopsquadapp/viewmodels/TapListViewModel.java
@@ -106,12 +106,7 @@ public class TapListViewModel extends ViewModel {
         Order order = new Order();
 
         order.discount = 0;
-
-        try {
-            order.invoice = parseTokenInvoiceId(token);
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
+        order.invoice = token;
         order.rewardId = 0;
         order.userId = getUserId();
         order.beers = getBeersByQuantity();
@@ -120,11 +115,7 @@ public class TapListViewModel extends ViewModel {
         return order;
     }
 
-    private String parseTokenInvoiceId(String token) throws JSONException {
-        JSONObject jsonObject = new JSONObject(token);
-        String token_id = jsonObject.getString("id");
-        return token_id;
-    }
+
 
     private String generatePseudoInvoice() {
         // TODO: Change this once Stripe is implemented.

--- a/webapp/services/get_all_orders.py
+++ b/webapp/services/get_all_orders.py
@@ -36,7 +36,7 @@ class GetAllOrders(webapp2.RequestHandler):
 					beer_name = "Unknown beer id " + beer_id
 				
 				order_beer_list.append({
-					'beer_id' : order_beer.beer_id,
+					'id' : order_beer.beer_id,
 					'beer_name' : beer_name,
 					'quantity' : order_beer.quantity
 				})

--- a/webapp/services/get_all_orders_by_user.py
+++ b/webapp/services/get_all_orders_by_user.py
@@ -22,6 +22,7 @@ class GetAllOrdersByUser(webapp2.RequestHandler):
 
 		for order in orders:
 			date = order.timestamp
+			# Please we need to use only 1 format!
 			date_string = date.strftime('%m/%d/%Y %H:%M:%S')
 
 			order_beer_query = OrderBeer.query( OrderBeer.order_id == order.key.id() ).order(-OrderBeer.quantity)
@@ -38,7 +39,7 @@ class GetAllOrdersByUser(webapp2.RequestHandler):
 					beer_name = "Unknown beer id " + beer_id
 				
 				order_beer_list.append({
-					'beer_id' : order_beer.beer_id,
+					'id' : order_beer.beer_id,
 					'beer_name' : beer_name,
 					'quantity' : order_beer.quantity
 				})


### PR DESCRIPTION
In this pull request is implemented reordering from the history of orders in the middle tab. I had to refactor out the payment code. 
Also I had to fix the name returned by `get_all_orders`  and `get_all_orders_by_user` since they didn't match the format in `add_order`.  I guess I should've been more diligent during code reviews for these.
Anyways, abstracting out an interface to add another payment service should be fairly straight forward (no android-tax considered).